### PR TITLE
Port to Vapoursynth API 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.dyn
 *.obj
 *.sublime-*
-build
+build*
+release*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ENABLE_PAR "Enable C++17 Parallel Execution" ON)
 
 find_package(Git REQUIRED)
 execute_process(COMMAND ${GIT_EXECUTABLE} describe --first-parent --tags --always OUTPUT_VARIABLE GIT_REPO_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REGEX REPLACE "(r[0-9]+).*" "\\1" VERSION ${GIT_REPO_VERSION})
+string(REGEX REPLACE "(r[0-9]+).*" "\\1" VERSION "${GIT_REPO_VERSION}")
 
 configure_file (
   "${PROJECT_SOURCE_DIR}/src/version.hpp.in"

--- a/include/dualsynth/ds_common.hpp
+++ b/include/dualsynth/ds_common.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <avisynth.h>
-#include <VapourSynth.h>
+#include <VapourSynth4.h>
 #include <cstring>
 #include <cmath>
 #include <string>
@@ -20,7 +20,7 @@
 #include "ds_videoinfo.hpp"
 #include "ds_frame.hpp"
 
-typedef void (*register_vsfilter_proc)(VSRegisterFunction, VSPlugin*);
+typedef void (*register_vsfilter_proc)(VSPlugin *plugin, const VSPLUGINAPI *vspapi);
 typedef void (*register_avsfilter_proc)(IScriptEnvironment* env);
 std::vector<register_vsfilter_proc> RegisterVSFilters();
 std::vector<register_avsfilter_proc> RegisterAVSFilters();

--- a/include/dualsynth/ds_filter.hpp
+++ b/include/dualsynth/ds_filter.hpp
@@ -14,7 +14,7 @@ struct Filter
   virtual const char* VSName() const { return "FilterFoo"; }
   virtual const char* AVSName() const { return "FilterFoo"; }
   virtual const MtMode AVSMode() const { return MT_SERIALIZED; }
-  virtual const VSFilterMode VSMode() const { return fmSerial; }
+  virtual const VSFilterMode VSMode() const { return fmFrameState; } // do we really need to run in this mode?
   virtual const std::vector<Param> Params() const = 0;
   virtual const std::string VSParams() const
   {
@@ -25,7 +25,7 @@ struct Filter
       if (!p.VSEnabled) continue;
       std::string type_name;
       switch(p.Type) {
-        case Clip: type_name = "clip"; break;
+        case Clip: type_name = "vnode"; break;
         case Integer: type_name = "int"; break;
         case Float: type_name = "float"; break;
         case Boolean: type_name = "int"; break;
@@ -40,6 +40,9 @@ struct Filter
     }
     return ss.str();
   };
+  virtual const std::string VSReturnType() const {
+    return std::string("clip:vnode;");
+  }
   virtual const std::string AVSParams() const
   {
     std::stringstream ss;

--- a/include/dualsynth/ds_format.hpp
+++ b/include/dualsynth/ds_format.hpp
@@ -15,30 +15,39 @@ struct DSFormat
   int BitsPerSample {8}, BytesPerSample {1};
   int Planes {3};
   DSFormat() {}
-  DSFormat(const VSFormat* format)
+  DSFormat(const VSVideoFormat format)
   {
-    Planes = format->numPlanes;
-    IsFamilyYUV = format->colorFamily == cmYUV || format->colorFamily == cmGray;
-    IsFamilyRGB = format->colorFamily == cmRGB;
-    IsFamilyYCC = format->colorFamily == cmYCoCg;
-    SSW = format->subSamplingW;
-    SSH = format->subSamplingH;
-    BitsPerSample = format->bitsPerSample;
-    BytesPerSample = format->bytesPerSample;
-    IsInteger = format->sampleType == stInteger;
-    IsFloat = format->sampleType == stFloat;
+    Planes = format.numPlanes;
+    IsFamilyYUV = format.colorFamily == cfYUV || format.colorFamily == cfGray;
+    IsFamilyRGB = format.colorFamily == cfRGB;
+    // IsFamilyYCC = format.colorFamily == cfYCoCg;
+    SSW = format.subSamplingW;
+    SSH = format.subSamplingH;
+    BitsPerSample = format.bitsPerSample;
+    BytesPerSample = format.bytesPerSample;
+    IsInteger = format.sampleType == stInteger;
+    IsFloat = format.sampleType == stFloat;
   }
 
-  const VSFormat* ToVSFormat(const VSCore* vscore, const VSAPI* vsapi) const
+  const VSVideoFormat ToVSFormat() const
   {
-    VSColorFamily family = cmYUV;
+    VSColorFamily family = cfYUV;
     if (IsFamilyYUV)
-      family = Planes == 1 ? cmGray : cmYUV;
+      family = Planes == 1 ? cfGray : cfYUV;
     else if (IsFamilyRGB)
-      family = cmRGB;
-    else if (IsFamilyYCC)
-      family = cmYCoCg;
-    return vsapi->registerFormat(family, IsInteger ? stInteger : stFloat, BitsPerSample, SSW, SSH, const_cast<VSCore*>(vscore));
+      family = cfRGB;
+    // else if (IsFamilyYCC)
+    //   family = cfYCoCg;
+    
+    VSVideoFormat format;
+    format.colorFamily = family;
+    format.sampleType = IsInteger ? stInteger : stFloat;
+    format.bitsPerSample = BitsPerSample;
+    format.bytesPerSample = BytesPerSample;
+    format.subSamplingW = SSW;
+    format.subSamplingH = SSH;
+    format.numPlanes = Planes;
+    return format;
   }
 
   DSFormat(int format)

--- a/include/dualsynth/ds_videoinfo.hpp
+++ b/include/dualsynth/ds_videoinfo.hpp
@@ -45,8 +45,8 @@ struct DSVideoInfo
     , Audio_NChannels(avsvi.nchannels)
     , Field(avsvi.image_type)
   { }
-  const VSVideoInfo* ToVSVI(const VSCore* vscore, const VSAPI* vsapi) {
-    return new VSVideoInfo {Format.ToVSFormat(vscore, vsapi), FPSNum, FPSDenom, Width, Height, Frames, 0};
+  const VSVideoInfo* ToVSVI() {
+    return new VSVideoInfo {Format.ToVSFormat(), FPSNum, FPSDenom, Width, Height, Frames};
   }
   const VideoInfo ToAVSVI() {
     return VideoInfo{Width, Height, static_cast<unsigned>(FPSNum), static_cast<unsigned>(FPSDenom), Frames, Format.ToAVSFormat(), Audio_SPS, Audio_SType, Audio_NSamples, Audio_NChannels, Field};

--- a/include/dualsynth/vs_wrapper.hpp
+++ b/include/dualsynth/vs_wrapper.hpp
@@ -7,10 +7,13 @@
 
 #pragma once
 
+#include <VapourSynth4.h>
+
 namespace Plugin {
   extern const char* Identifier;
   extern const char* Namespace;
   extern const char* Description;
+  extern const int Version;
 }
 
 namespace VSInterface {
@@ -20,85 +23,86 @@ namespace VSInterface {
     const VSMap *_in;
     const VSAPI *_vsapi;
     int _err;
+
     void Read(const char* name, int& output) override {
       auto _default = output;
-      output = static_cast<int>(_vsapi->propGetInt(_in, name, 0, &_err));
+      output = static_cast<int>(_vsapi->mapGetInt(_in, name, 0, &_err));
       if (_err) output = _default;
     }
     void Read(const char* name, int64_t& output) override {
       auto _default = output;
-      output = _vsapi->propGetInt(_in, name, 0, &_err);
+      output = _vsapi->mapGetInt(_in, name, 0, &_err);
       if (_err) output = _default;
     }
     void Read(const char* name, float& output) override {
       auto _default = output;
-      output = static_cast<float>(_vsapi->propGetFloat(_in, name, 0, &_err));
+      output = static_cast<float>(_vsapi->mapGetFloat(_in, name, 0, &_err));
       if (_err) output = _default;
     }
     void Read(const char* name, double& output) override {
       auto _default = output;
-      output = _vsapi->propGetFloat(_in, name, 0, &_err);
+      output = _vsapi->mapGetFloat(_in, name, 0, &_err);
       if (_err) output = _default;
     }
     void Read(const char* name, bool& output) override {
-      auto output_int = _vsapi->propGetInt(_in, name, 0, &_err);
+      auto output_int = _vsapi->mapGetInt(_in, name, 0, &_err);
       if (!_err) output = output_int != 0;
     }
     void Read(const char* name, std::string& output) override {
-      auto output_str = _vsapi->propGetData(_in, name, 0, &_err);
+      auto output_str = _vsapi->mapGetData(_in, name, 0, &_err);
       if (!_err) output = output_str;
     }
     void Read(const char* name, std::vector<int>& output) override {
-      auto size = _vsapi->propNumElements(_in, name);
+      auto size = _vsapi->mapNumElements(_in, name);
       if (size < 0) return;
       output.clear();
       for (int i = 0; i < size; i++)
-        output.push_back(static_cast<int>(_vsapi->propGetInt(_in, name, i, &_err)));
+        output.push_back(static_cast<int>(_vsapi->mapGetInt(_in, name, i, &_err)));
     }
     void Read(const char* name, std::vector<int64_t>& output) override {
-      auto size = _vsapi->propNumElements(_in, name);
+      auto size = _vsapi->mapNumElements(_in, name);
       if (size < 0) return;
       output.clear();
       for (int i = 0; i < size; i++)
-        output.push_back(_vsapi->propGetInt(_in, name, i, &_err));
+        output.push_back(_vsapi->mapGetInt(_in, name, i, &_err));
     }
     void Read(const char* name, std::vector<float>& output) override {
-      auto size = _vsapi->propNumElements(_in, name);
+      auto size = _vsapi->mapNumElements(_in, name);
       if (size < 0) return;
       output.clear();
       for (int i = 0; i < size; i++)
-        output.push_back(static_cast<float>(_vsapi->propGetFloat(_in, name, i, &_err)));
+        output.push_back(static_cast<float>(_vsapi->mapGetFloat(_in, name, i, &_err)));
     }
     void Read(const char* name, std::vector<double>& output) override {
-      auto size = _vsapi->propNumElements(_in, name);
+      auto size = _vsapi->mapNumElements(_in, name);
       if (size < 0) return;
       output.clear();
       for (int i = 0; i < size; i++)
-        output.push_back(_vsapi->propGetFloat(_in, name, i, &_err));
+        output.push_back(_vsapi->mapGetFloat(_in, name, i, &_err));
     }
     void Read(const char* name, std::vector<bool>& output) override {
-      auto size = _vsapi->propNumElements(_in, name);
+      auto size = _vsapi->mapNumElements(_in, name);
       if (size < 0) return;
       output.clear();
       for (int i = 0; i < size; i++)
-        output.push_back(_vsapi->propGetInt(_in, name, i, &_err));
+        output.push_back(_vsapi->mapGetInt(_in, name, i, &_err));
     }
     void Read(const char* name, void*& output) override {
-      output = reinterpret_cast<void *>(_vsapi->propGetNode(_in, name, 0, &_err));
+      output = reinterpret_cast<void *>(_vsapi->mapGetNode(_in, name, 0, &_err));
     }
     void Free(void*& clip) override {
-      _vsapi->freeNode(reinterpret_cast<VSNodeRef *>(clip));
+      _vsapi->freeNode(reinterpret_cast<VSNode *>(clip));
       clip = nullptr;
     }
     VSInDelegator(const VSMap *in, const VSAPI *vsapi) : _in(in), _vsapi(vsapi) {}
   };
 
   struct VSFetchFrameFunctor final : FetchFrameFunctor {
-    VSNodeRef *_vs_clip;
+    VSNode *_vs_clip;
     VSCore *_core;
     const VSAPI *_vsapi;
     VSFrameContext *_frameCtx;
-    VSFetchFrameFunctor(VSNodeRef *clip, VSCore *core, const VSAPI *vsapi)
+    VSFetchFrameFunctor(VSNode *clip, VSCore *core, const VSAPI *vsapi)
       : _vs_clip(clip), _core(core), _vsapi(vsapi) {}
     DSFrame operator()(int n) override {
       return DSFrame(_vsapi->getFrameFilter(n, _vs_clip, _frameCtx), _core, _vsapi);
@@ -109,13 +113,6 @@ namespace VSInterface {
   };
 
   template<typename FilterType>
-  void VS_CC Initialize(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi) {
-    auto Data = reinterpret_cast<FilterType*>(*instanceData);
-    auto output_vi = Data->GetOutputVI();
-    vsapi->setVideoInfo(output_vi.ToVSVI(core, vsapi), 1, node);
-  }
-
-  template<typename FilterType>
   void VS_CC Delete(void *instanceData, VSCore *core, const VSAPI *vsapi) {
     auto filter = reinterpret_cast<FilterType*>(instanceData);
     auto functor = reinterpret_cast<VSFetchFrameFunctor*>(filter->fetch_frame);
@@ -124,8 +121,8 @@ namespace VSInterface {
   }
 
   template<typename FilterType>
-  const VSFrameRef* VS_CC GetFrame(int n, int activationReason, void **instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {
-    auto filter = reinterpret_cast<FilterType*>(*instanceData);
+  const VSFrame* VS_CC GetFrame(int n, int activationReason, void *instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {
+    auto filter = reinterpret_cast<FilterType*>(instanceData);
     auto functor = reinterpret_cast<VSFetchFrameFunctor*>(filter->fetch_frame);
     if (functor)
       functor->_frameCtx = frameCtx;
@@ -171,38 +168,39 @@ namespace VSInterface {
       try {
         argument.Read("clip", clip);
         if (clip) {
-          auto vs_clip = reinterpret_cast<VSNodeRef*>(clip);
+          auto vs_clip = reinterpret_cast<VSNode*>(clip);
           functor = new VSFetchFrameFunctor(vs_clip, core, vsapi);
           input_vi = DSVideoInfo(vsapi->getVideoInfo(vs_clip));
         }
       }
       catch(const char *) { /* No clip, source filter */ }
       filter->Initialize(&argument, input_vi, functor);
-      vsapi->createFilter(in, out, filter->VSName(), Initialize<FilterType>, GetFrame<FilterType>, Delete<FilterType>, filter->VSMode(), 0, filter, core);
+      vsapi->createVideoFilter(out, filter->VSName(), filter->GetOutputVI().ToVSVI(), GetFrame<FilterType>, Delete<FilterType>, filter->VSMode(), nullptr, 0, filter, core);
     }
     catch(const char *err){
       char msg_buff[256];
       snprintf(msg_buff, 256, "%s: %s", filter->VSName(), err);
-      vsapi->setError(out, msg_buff);
+      vsapi->mapSetError(out, msg_buff);
       delete filter;
     }
   }
 
   template<typename FilterType>
-  void RegisterFilter(VSRegisterFunction registerFunc, VSPlugin* vsplugin) {
+  void RegisterFilter(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {
     FilterType filter;
-    registerFunc(filter.VSName(), filter.VSParams().c_str(), Create<FilterType>, nullptr, vsplugin);
+    vspapi->registerFunction(filter.VSName(), filter.VSParams().c_str(), filter.VSReturnType().c_str(), Create<FilterType>, nullptr, plugin);
+    // vspapi->registerFunction(filter.VSName(), filter.VSParams().c_str(), Create<FilterType>, nullptr, plugin);
   }
 
-  void RegisterPlugin(VSConfigPlugin configFunc, VSPlugin* vsplugin) {
-    configFunc(Plugin::Identifier, Plugin::Namespace, Plugin::Description, VAPOURSYNTH_API_VERSION, 1, vsplugin);
+  void RegisterPlugin(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {
+    vspapi->configPlugin(Plugin::Identifier, Plugin::Namespace, Plugin::Description, Plugin::Version, VAPOURSYNTH_API_VERSION, 1, plugin);
   }
 }
 
-VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin* vsplugin) {
-  VSInterface::RegisterPlugin(configFunc, vsplugin);
-  auto filters = RegisterVSFilters();
-  for (auto &&RegisterFilter : filters) {
-    RegisterFilter(registerFunc, vsplugin);
-  }
+VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {
+    VSInterface::RegisterPlugin(plugin, vspapi);
+    auto filters = RegisterVSFilters();
+    for(auto&& RegisterFunc: filters) {
+        RegisterFunc(plugin, vspapi);
+    }
 }

--- a/include/vapoursynth/VSConstants4.h
+++ b/include/vapoursynth/VSConstants4.h
@@ -1,0 +1,93 @@
+/*
+* Copyright (c) 2021 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef VSCONSTANTS4_H
+#define VSCONSTANTS4_H
+
+typedef enum VSColorRange {
+	VSC_RANGE_FULL = 0,
+	VSC_RANGE_LIMITED = 1
+} VSColorRange;
+
+typedef enum VSChromaLocation {
+	VSC_CHROMA_LEFT = 0,
+	VSC_CHROMA_CENTER = 1,
+	VSC_CHROMA_TOP_LEFT = 2,
+	VSC_CHROMA_TOP = 3,
+	VSC_CHROMA_BOTTOM_LEFT = 4,
+	VSC_CHROMA_BOTTOM = 5
+} VSChromaLocation;
+
+typedef enum VSFieldBased {
+	VSC_FIELD_PROGRESSIVE = 0,
+	VSC_FIELD_BOTTOM = 1,
+	VSC_FIELD_TOP = 2
+} VSFieldBased;
+
+typedef enum VSMatrixCoefficients {
+	VSC_MATRIX_RGB = 0,
+	VSC_MATRIX_BT709 = 1,
+	VSC_MATRIX_UNSPECIFIED = 2,
+	VSC_MATRIX_FCC = 4,
+	VSC_MATRIX_BT470_BG = 5,
+	VSC_MATRIX_ST170_M = 6,  /* Equivalent to 5. */
+	VSC_MATRIX_ST240_M = 7,
+	VSC_MATRIX_YCGCO = 8,
+	VSC_MATRIX_BT2020_NCL = 9,
+	VSC_MATRIX_BT2020_CL = 10,
+	VSC_MATRIX_CHROMATICITY_DERIVED_NCL = 12,
+	VSC_MATRIX_CHROMATICITY_DERIVED_CL = 13,
+	VSC_MATRIX_ICTCP = 14
+} VSMatrixCoefficients;
+
+typedef enum VSTransferCharacteristics {
+	VSC_TRANSFER_BT709 = 1,
+	VSC_TRANSFER_UNSPECIFIED = 2,
+	VSC_TRANSFER_BT470_M = 4,
+	VSC_TRANSFER_BT470_BG = 5,
+	VSC_TRANSFER_BT601 = 6,  /* Equivalent to 1. */
+	VSC_TRANSFER_ST240_M = 7,
+	VSC_TRANSFER_LINEAR = 8,
+	VSC_TRANSFER_LOG_100 = 9,
+	VSC_TRANSFER_LOG_316 = 10,
+	VSC_TRANSFER_IEC_61966_2_4 = 11,
+	VSC_TRANSFER_IEC_61966_2_1 = 13,
+	VSC_TRANSFER_BT2020_10 = 14, /* Equivalent to 1. */
+	VSC_TRANSFER_BT2020_12 = 15, /* Equivalent to 1. */
+	VSC_TRANSFER_ST2084 = 16,
+	VSC_TRANSFER_ARIB_B67 = 18
+} VSTransferCharacteristics;
+
+typedef enum VSColorPrimaries {
+	VSC_PRIMARIES_BT709 = 1,
+	VSC_PRIMARIES_UNSPECIFIED = 2,
+	VSC_PRIMARIES_BT470_M = 4,
+	VSC_PRIMARIES_BT470_BG = 5,
+	VSC_PRIMARIES_ST170_M = 6,
+	VSC_PRIMARIES_ST240_M = 7,  /* Equivalent to 6. */
+	VSC_PRIMARIES_FILM = 8,
+	VSC_PRIMARIES_BT2020 = 9,
+	VSC_PRIMARIES_ST428 = 10,
+	VSC_PRIMARIES_ST431_2 = 11,
+	VSC_PRIMARIES_ST432_1 = 12,
+	VSC_PRIMARIES_EBU3213_E = 22
+} VSColorPrimaries;
+
+#endif /* VSCONSTANTS4_H */

--- a/include/vapoursynth/VSHelper.h
+++ b/include/vapoursynth/VSHelper.h
@@ -27,7 +27,7 @@
 #define inline _inline
 #endif
 
-/* A kinda portable definition of the C99 restrict keyword (or its inofficial C++ equivalent) */
+/* A kinda portable definition of the C99 restrict keyword (or its unofficial C++ equivalent) */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* Available in C99 */
 #define VS_RESTRICT restrict
 #elif defined(__cplusplus) || defined(_MSC_VER) /* Almost all relevant C++ compilers support it so just assume it works */

--- a/include/vapoursynth/VSHelper4.h
+++ b/include/vapoursynth/VSHelper4.h
@@ -1,0 +1,224 @@
+/*****************************************************************************
+* Copyright (c) 2012-2020 Fredrik Mellbin
+* --- Legal stuff ---
+* This program is free software. It comes without any warranty, to
+* the extent permitted by applicable law. You can redistribute it
+* and/or modify it under the terms of the Do What The Fuck You Want
+* To Public License, Version 2, as published by Sam Hocevar. See
+* http://sam.zoy.org/wtfpl/COPYING for more details.
+*****************************************************************************/
+
+#ifndef VSHELPER4_H
+#define VSHELPER4_H
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <math.h>
+#include <float.h>
+#ifdef _WIN32
+#include <malloc.h>
+#endif
+#include "VapourSynth4.h"
+
+#define VSH_STD_PLUGIN_ID "com.vapoursynth.std"
+#define VSH_RESIZE_PLUGIN_ID "com.vapoursynth.resize"
+#define VSH_TEXT_PLUGIN_ID "com.vapoursynth.text"
+
+#ifdef __cplusplus
+namespace vsh {
+#define VSH4_MANGLE_FUNCTION_NAME(name) name
+#define VSH4_BOOLEAN_TYPE bool
+#else
+#define VSH4_MANGLE_FUNCTION_NAME(name) vsh_##name
+#define VSH4_BOOLEAN_TYPE int
+#endif
+
+/* Visual Studio doesn't recognize inline in c mode */
+#if defined(_MSC_VER) && !defined(__cplusplus)
+#define inline _inline
+#endif
+
+/* A kinda portable definition of the C99 restrict keyword (or its unofficial C++ equivalent) */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* Available in C99 */
+#define VS_RESTRICT restrict
+#elif defined(__cplusplus) || defined(_MSC_VER) /* Almost all relevant C++ compilers support it so just assume it works */
+#define VS_RESTRICT __restrict
+#else /* Not supported */
+#define VS_RESTRICT
+#endif
+
+#ifdef _WIN32
+#define VSH_ALIGNED_MALLOC(pptr, size, alignment) do { *(pptr) = _aligned_malloc((size), (alignment)); } while (0)
+#define VSH_ALIGNED_FREE(ptr) do { _aligned_free((ptr)); } while (0)
+#else
+#define VSH_ALIGNED_MALLOC(pptr, size, alignment) do { if(posix_memalign((void**)(pptr), (alignment), (size))) *((void**)pptr) = NULL; } while (0)
+#define VSH_ALIGNED_FREE(ptr) do { free((ptr)); } while (0)
+#endif
+
+#define VSMAX(a,b) ((a) > (b) ? (a) : (b))
+#define VSMIN(a,b) ((a) > (b) ? (b) : (a))
+
+#ifdef __cplusplus 
+/* A nicer templated malloc for all the C++ users out there */
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+template<typename T = void>
+#else
+template<typename T>
+#endif
+static inline T *vsh_aligned_malloc(size_t size, size_t alignment) {
+#ifdef _WIN32
+    return (T *)_aligned_malloc(size, alignment);
+#else
+    void *tmp = NULL;
+    if (posix_memalign(&tmp, alignment, size))
+        tmp = 0;
+    return (T *)tmp;
+#endif
+}
+
+static inline void vsh_aligned_free(void *ptr) {
+    VSH_ALIGNED_FREE(ptr);
+}
+#endif /* __cplusplus */
+
+/* convenience function for checking if the format never changes between frames */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isConstantVideoFormat)(const VSVideoInfo *vi) {
+    return vi->height > 0 && vi->width > 0 && vi->format.colorFamily != cfUndefined;
+}
+
+/* convenience function to check if two clips have the same format (unknown/changeable will be considered the same too) */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isSameVideoFormat)(const VSVideoFormat *v1, const VSVideoFormat *v2) {
+    return v1->colorFamily == v2->colorFamily && v1->sampleType == v2->sampleType && v1->bitsPerSample == v2->bitsPerSample && v1->subSamplingW == v2->subSamplingW && v1->subSamplingH == v2->subSamplingH;
+}
+
+/* convenience function to check if a clip has the same format as a format id */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isSameVideoPresetFormat)(unsigned presetFormat, const VSVideoFormat *v, VSCore *core, const VSAPI *vsapi) {
+    return vsapi->queryVideoFormatID(v->colorFamily, v->sampleType, v->bitsPerSample, v->subSamplingW, v->subSamplingH, core) == presetFormat;
+}
+
+/* convenience function to check for if two clips have the same format (but not framerate) while also including width and height (unknown/changeable will be considered the same too) */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isSameVideoInfo)(const VSVideoInfo *v1, const VSVideoInfo *v2) {
+    return v1->height == v2->height && v1->width == v2->width && VSH4_MANGLE_FUNCTION_NAME(isSameVideoFormat)(&v1->format, &v2->format);
+}
+
+/* convenience function to check for if two clips have the same format while also including samplerate (unknown/changeable will be considered the same too) */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isSameAudioFormat)(const VSAudioFormat *a1, const VSAudioFormat *a2) {
+    return a1->bitsPerSample == a2->bitsPerSample && a1->sampleType == a2->sampleType && a1->channelLayout == a2->channelLayout;
+}
+
+/* convenience function to check for if two clips have the same format while also including samplerate (unknown/changeable will be considered the same too) */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(isSameAudioInfo)(const VSAudioInfo *a1, const VSAudioInfo *a2) {
+    return a1->sampleRate == a2->sampleRate && VSH4_MANGLE_FUNCTION_NAME(isSameAudioFormat)(&a1->format, &a2->format);
+}
+
+/* multiplies and divides a rational number, such as a frame duration, in place and reduces the result */
+static inline void VSH4_MANGLE_FUNCTION_NAME(muldivRational)(int64_t *num, int64_t *den, int64_t mul, int64_t div) {
+    /* do nothing if the rational number is invalid */
+    if (!*den)
+        return;
+
+    /* nobody wants to accidentally divide by zero */
+    assert(div);
+
+    int64_t a, b;
+    *num *= mul;
+    *den *= div;
+    a = *num;
+    b = *den;
+    while (b != 0) {
+        int64_t t = a;
+        a = b;
+        b = t % b;
+    }
+    if (a < 0)
+        a = -a;
+    *num /= a;
+    *den /= a;
+}
+
+/* reduces a rational number */
+static inline void VSH4_MANGLE_FUNCTION_NAME(reduceRational)(int64_t *num, int64_t *den) {
+    VSH4_MANGLE_FUNCTION_NAME(muldivRational)(num, den, 1, 1);
+}
+
+/* add two rational numbers and reduces the result */
+static inline void VSH4_MANGLE_FUNCTION_NAME(addRational)(int64_t *num, int64_t *den, int64_t addnum, int64_t addden) {
+    /* do nothing if the rational number is invalid */
+    if (!*den)
+        return;
+
+    /* nobody wants to accidentally add an invalid rational number */
+    assert(addden);
+
+    if (*den == addden) {
+        *num += addnum;
+    } else {
+        int64_t temp = addden;
+        addnum *= *den;
+        addden *= *den;
+        *num *= temp;
+        *den *= temp;
+
+        *num += addnum;
+
+        VSH4_MANGLE_FUNCTION_NAME(reduceRational)(num, den);
+    }
+}
+
+/* converts an int64 to int with saturation, useful to silence warnings when reading int properties among other things */
+static inline int VSH4_MANGLE_FUNCTION_NAME(int64ToIntS)(int64_t i) {
+    if (i > INT_MAX)
+        return INT_MAX;
+    else if (i < INT_MIN)
+        return INT_MIN;
+    else return (int)i;
+}
+
+/* converts a double to float with saturation, useful to silence warnings when reading float properties among other things */
+static inline float VSH4_MANGLE_FUNCTION_NAME(doubleToFloatS)(double d) {
+    if (!isfinite(d))
+        return (float)d;
+    else if (d > FLT_MAX)
+        return FLT_MAX;
+    else if (d < -FLT_MAX)
+        return -FLT_MAX;
+    else
+        return (float)d;
+}
+
+static inline void VSH4_MANGLE_FUNCTION_NAME(bitblt)(void *dstp, ptrdiff_t dst_stride, const void *srcp, ptrdiff_t src_stride, size_t row_size, size_t height) {
+    if (height) {
+        if (src_stride == dst_stride && src_stride == (ptrdiff_t)row_size) {
+            memcpy(dstp, srcp, row_size * height);
+        } else {
+            const uint8_t *srcp8 = (const uint8_t *)srcp;
+            uint8_t *dstp8 = (uint8_t *)dstp;
+            size_t i;
+            for (i = 0; i < height; i++) {
+                memcpy(dstp8, srcp8, row_size);
+                srcp8 += src_stride;
+                dstp8 += dst_stride;
+            }
+        }
+    }
+}
+
+/* check if the frame dimensions are valid for a given format */
+/* returns non-zero for valid width and height */
+static inline VSH4_BOOLEAN_TYPE VSH4_MANGLE_FUNCTION_NAME(areValidDimensions)(const VSVideoFormat *fi, int width, int height) {
+    return !(width % (1 << fi->subSamplingW) || height % (1 << fi->subSamplingH));
+}
+
+/* Visual Studio doesn't recognize inline in c mode */
+#if defined(_MSC_VER) && !defined(__cplusplus)
+#undef inline
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/vapoursynth/VSScript.h
+++ b/include/vapoursynth/VSScript.h
@@ -62,6 +62,7 @@ VS_API(int) vsscript_createScript(VSScript **handle);
 
 VS_API(void) vsscript_freeScript(VSScript *handle);
 VS_API(const char *) vsscript_getError(VSScript *handle);
+VS_API(int) vsscript_getExitCode(VSScript *handle);
 /* The node returned must be freed using freeNode() before calling vsscript_freeScript() */
 VS_API(VSNodeRef *) vsscript_getOutput(VSScript *handle, int index);
 /* Both nodes returned must be freed using freeNode() before calling vsscript_freeScript(), the alpha node pointer will only be set if an alpha clip has been set in the script */

--- a/include/vapoursynth/VSScript4.h
+++ b/include/vapoursynth/VSScript4.h
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2013-2020 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef VSSCRIPT4_H
+#define VSSCRIPT4_H
+
+#include "VapourSynth4.h"
+
+#define VSSCRIPT_API_MAJOR 4
+#define VSSCRIPT_API_MINOR 1
+#define VSSCRIPT_API_VERSION VS_MAKE_VERSION(VSSCRIPT_API_MAJOR, VSSCRIPT_API_MINOR)
+
+typedef struct VSScript VSScript;
+typedef struct VSSCRIPTAPI VSSCRIPTAPI;
+
+struct VSSCRIPTAPI {
+    /* Returns the highest supported VSSCRIPT_API_VERSION */
+    int (VS_CC *getAPIVersion)(void) VS_NOEXCEPT;
+
+    /* Convenience function for retrieving a VSAPI pointer without having to use the VapourSynth library. Always pass VAPOURSYNTH_API_VERSION */
+    const VSAPI *(VS_CC *getVSAPI)(int version) VS_NOEXCEPT;
+
+    /* 
+    * Providing a pre-created core is useful for setting core creation flags, log callbacks, preload specific plugins and many other things.
+    * You must create a VSScript object before evaluating a script. Always takes ownership of the core even on failure. Returns NULL on failure.
+    * Pass NULL to have a core automatically created with the default options.
+    */
+    VSScript *(VS_CC *createScript)(VSCore *core) VS_NOEXCEPT;
+
+    /* The core is valid as long as the environment exists, return NULL on error */
+    VSCore *(VS_CC *getCore)(VSScript *handle) VS_NOEXCEPT;
+
+    /*
+    * Evaluates a script passed in the buffer argument. The scriptFilename is only used for display purposes. in Python
+    * it means that the main module won't be unnamed in error messages.
+    * 
+    * Returns 0 on success.
+    * 
+    * Note that calling any function other than getError() and freeScript() on a VSScript object in the error state
+    * will result in undefined behavior.
+    */
+    int (VS_CC *evaluateBuffer)(VSScript *handle, const char *buffer, const char *scriptFilename) VS_NOEXCEPT;
+
+    /* Convenience version of the above function that loads the script from scriptFilename and passes as the buffer to evaluateBuffer */
+    int (VS_CC *evaluateFile)(VSScript *handle, const char *scriptFilename) VS_NOEXCEPT;
+
+    /* Returns NULL on success, otherwise an error message */
+    const char *(VS_CC *getError)(VSScript *handle) VS_NOEXCEPT;
+
+    /* Returns the script's reported exit code */
+    int (VS_CC *getExitCode)(VSScript *handle) VS_NOEXCEPT;
+
+    /* Fetches a variable of any VSMap storable type set in a script. It is stored in the key with the same name in dst. Returns 0 on success. */
+    int (VS_CC *getVariable)(VSScript *handle, const char *name, VSMap *dst) VS_NOEXCEPT;
+
+    /* Sets all keys in the provided VSMap as variables in the script. Returns 0 on success. */
+    int (VS_CC *setVariables)(VSScript *handle, const VSMap *vars) VS_NOEXCEPT;
+
+    /*
+    * The returned nodes must be freed using freeNode() before calling freeScript() since they may depend on data in the VSScript
+    * environment. Returns NULL if no node was set as output in the script. Index 0 is used by default in scripts and other
+    * values are rarely used.
+    */
+    VSNode *(VS_CC *getOutputNode)(VSScript *handle, int index) VS_NOEXCEPT;
+    VSNode *(VS_CC *getOutputAlphaNode)(VSScript *handle, int index) VS_NOEXCEPT;
+    int (VS_CC *getAltOutputMode)(VSScript *handle, int index) VS_NOEXCEPT;
+
+    void (VS_CC *freeScript)(VSScript *handle) VS_NOEXCEPT;
+
+    /*
+    * Set whether or not the working directory is temporarily changed to the same
+    * location as the script file when evaluateFile is called. Off by default.
+    */
+    void (VS_CC *evalSetWorkingDir)(VSScript *handle, int setCWD) VS_NOEXCEPT;
+
+};
+
+VS_API(const VSSCRIPTAPI *) getVSScriptAPI(int version) VS_NOEXCEPT;
+
+#endif /* VSSCRIPT4_H */

--- a/include/vapoursynth/VapourSynth.h
+++ b/include/vapoursynth/VapourSynth.h
@@ -35,9 +35,15 @@
 #    else
 #        define VS_NOEXCEPT
 #    endif
+#    if __cplusplus >= 201402L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#        define VS_DEPRECATE(REASON) [[deprecated(REASON)]]
+#    else
+#        define VS_DEPRECATE(REASON)
+#    endif
 #else
 #    define VS_EXTERN_C
 #    define VS_NOEXCEPT
+#    define VS_DEPRECATE(REASON)
 #endif
 
 #if defined(_WIN32) && !defined(_WIN64)
@@ -86,7 +92,7 @@ typedef enum VSSampleType {
     stFloat = 1
 } VSSampleType;
 
-/* The +10 is so people won't be using the constants interchangably "by accident" */
+/* The +10 is so people won't be using the constants interchangeably "by accident" */
 typedef enum VSPresetFormat {
     pfNone = 0,
 
@@ -243,7 +249,9 @@ typedef void (VS_CC *VSMessageHandlerFree)(void *userData);
 struct VSAPI {
     VSCore *(VS_CC *createCore)(int threads) VS_NOEXCEPT;
     void (VS_CC *freeCore)(VSCore *core) VS_NOEXCEPT;
-    const VSCoreInfo *(VS_CC *getCoreInfo)(VSCore *core) VS_NOEXCEPT; /* deprecated as of api 3.6, use getCoreInfo2 instead */
+
+    VS_DEPRECATE("getCoreInfo has been deprecated as of api 3.6, use getCoreInfo2 instead")
+    const VSCoreInfo *(VS_CC *getCoreInfo)(VSCore *core) VS_NOEXCEPT;
 
     const VSFrameRef *(VS_CC *cloneFrameRef)(const VSFrameRef *f) VS_NOEXCEPT;
     VSNodeRef *(VS_CC *cloneNodeRef)(VSNodeRef *node) VS_NOEXCEPT;
@@ -322,7 +330,10 @@ struct VSAPI {
     int64_t (VS_CC *setMaxCacheSize)(int64_t bytes, VSCore *core) VS_NOEXCEPT;
     int (VS_CC *getOutputIndex)(VSFrameContext *frameCtx) VS_NOEXCEPT;
     VSFrameRef *(VS_CC *newVideoFrame2)(const VSFormat *format, int width, int height, const VSFrameRef **planeSrc, const int *planes, const VSFrameRef *propSrc, VSCore *core) VS_NOEXCEPT;
-    void (VS_CC *setMessageHandler)(VSMessageHandler handler, void *userData) VS_NOEXCEPT; /* deprecated as of api 3.6, use addMessageHandler and removeMessageHandler instead */
+    
+    VS_DEPRECATE("setMessageHandler has been deprecated as of api 3.6, use addMessageHandler and removeMessageHandler instead")
+    void (VS_CC *setMessageHandler)(VSMessageHandler handler, void *userData) VS_NOEXCEPT;
+    
     int (VS_CC *setThreadCount)(int threads, VSCore *core) VS_NOEXCEPT;
 
     const char *(VS_CC *getPluginPath)(const VSPlugin *plugin) VS_NOEXCEPT;

--- a/include/vapoursynth/VapourSynth4.h
+++ b/include/vapoursynth/VapourSynth4.h
@@ -1,0 +1,488 @@
+/*
+* Copyright (c) 2012-2021 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef VAPOURSYNTH4_H
+#define VAPOURSYNTH4_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define VS_MAKE_VERSION(major, minor) (((major) << 16) | (minor))
+#define VAPOURSYNTH_API_MAJOR 4
+#define VAPOURSYNTH_API_MINOR 0
+#define VAPOURSYNTH_API_VERSION VS_MAKE_VERSION(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
+
+#define VS_AUDIO_FRAME_SAMPLES 3072
+
+/* Convenience for C++ users. */
+#ifdef __cplusplus
+#    define VS_EXTERN_C extern "C"
+#    if __cplusplus >= 201103L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201103L)
+#        define VS_NOEXCEPT noexcept
+#    else
+#        define VS_NOEXCEPT
+#    endif
+#else
+#    define VS_EXTERN_C
+#    define VS_NOEXCEPT
+#endif
+
+#if defined(_WIN32) && !defined(_WIN64)
+#    define VS_CC __stdcall
+#else
+#    define VS_CC
+#endif
+
+/* And now for some symbol hide-and-seek... */
+#if defined(_WIN32) /* Windows being special */
+#    define VS_EXTERNAL_API(ret) VS_EXTERN_C __declspec(dllexport) ret VS_CC
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#    define VS_EXTERNAL_API(ret) VS_EXTERN_C __attribute__((visibility("default"))) ret VS_CC
+#else
+#    define VS_EXTERNAL_API(ret) VS_EXTERN_C ret VS_CC
+#endif
+
+#if !defined(VS_CORE_EXPORTS) && defined(_WIN32)
+#    define VS_API(ret) VS_EXTERN_C __declspec(dllimport) ret VS_CC
+#else
+#    define VS_API(ret) VS_EXTERNAL_API(ret)
+#endif
+
+typedef struct VSFrame VSFrame;
+typedef struct VSNode VSNode;
+typedef struct VSCore VSCore;
+typedef struct VSPlugin VSPlugin;
+typedef struct VSPluginFunction VSPluginFunction;
+typedef struct VSFunction VSFunction;
+typedef struct VSMap VSMap;
+typedef struct VSLogHandle VSLogHandle;
+typedef struct VSFrameContext VSFrameContext;
+typedef struct VSPLUGINAPI VSPLUGINAPI;
+typedef struct VSAPI VSAPI;
+
+typedef enum VSColorFamily {
+    cfUndefined = 0,
+    cfGray      = 1,
+    cfRGB       = 2,
+    cfYUV       = 3
+} VSColorFamily;
+
+typedef enum VSSampleType {
+    stInteger = 0,
+    stFloat = 1
+} VSSampleType;
+
+#define VS_MAKE_VIDEO_ID(colorFamily, sampleType, bitsPerSample, subSamplingW, subSamplingH) ((colorFamily << 28) | (sampleType << 24) | (bitsPerSample << 16) | (subSamplingW << 8) | (subSamplingH << 0))
+
+typedef enum VSPresetFormat {
+    pfNone = 0,
+
+    pfGray8 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 8, 0, 0),
+    pfGray9 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 9, 0, 0),
+    pfGray10 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 10, 0, 0),
+    pfGray12 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 12, 0, 0),
+    pfGray14 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 14, 0, 0),
+    pfGray16 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 16, 0, 0),
+    pfGray32 = VS_MAKE_VIDEO_ID(cfGray, stInteger, 32, 0, 0),
+
+    pfGrayH = VS_MAKE_VIDEO_ID(cfGray, stFloat, 16, 0, 0),
+    pfGrayS = VS_MAKE_VIDEO_ID(cfGray, stFloat, 32, 0, 0),
+
+    pfYUV410P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 2, 2),
+    pfYUV411P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 2, 0),
+    pfYUV440P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 0, 1),
+
+    pfYUV420P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 1, 1),
+    pfYUV422P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 1, 0),
+    pfYUV444P8 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 8, 0, 0),
+
+    pfYUV420P9 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 9, 1, 1),
+    pfYUV422P9 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 9, 1, 0),
+    pfYUV444P9 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 9, 0, 0),
+
+    pfYUV420P10 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 10, 1, 1),
+    pfYUV422P10 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 10, 1, 0),
+    pfYUV444P10 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 10, 0, 0),
+
+    pfYUV420P12 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 12, 1, 1),
+    pfYUV422P12 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 12, 1, 0),
+    pfYUV444P12 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 12, 0, 0),
+
+    pfYUV420P14 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 14, 1, 1),
+    pfYUV422P14 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 14, 1, 0),
+    pfYUV444P14 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 14, 0, 0),
+
+    pfYUV420P16 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 16, 1, 1),
+    pfYUV422P16 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 16, 1, 0),
+    pfYUV444P16 = VS_MAKE_VIDEO_ID(cfYUV, stInteger, 16, 0, 0),
+
+    pfYUV444PH = VS_MAKE_VIDEO_ID(cfYUV, stFloat, 16, 0, 0),
+    pfYUV444PS = VS_MAKE_VIDEO_ID(cfYUV, stFloat, 32, 0, 0),
+
+    pfRGB24 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 8, 0, 0),
+    pfRGB27 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 9, 0, 0),
+    pfRGB30 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 10, 0, 0),
+    pfRGB36 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 12, 0, 0),
+    pfRGB42 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 14, 0, 0),
+    pfRGB48 = VS_MAKE_VIDEO_ID(cfRGB, stInteger, 16, 0, 0),
+
+    pfRGBH = VS_MAKE_VIDEO_ID(cfRGB, stFloat, 16, 0, 0),
+    pfRGBS = VS_MAKE_VIDEO_ID(cfRGB, stFloat, 32, 0, 0),
+} VSPresetFormat;
+
+#undef VS_MAKE_VIDEO_ID
+
+
+typedef enum VSFilterMode {
+    fmParallel = 0, /* completely parallel execution */
+    fmParallelRequests = 1, /* for filters that are serial in nature but can request one or more frames they need in advance */
+    fmUnordered = 2, /* for filters that modify their internal state every request like source filters that read a file */
+    fmFrameState = 3 /* DO NOT USE UNLESS ABSOLUTELY NECESSARY, for compatibility with external code that can only keep the processing state of a single frame at a time */
+} VSFilterMode;
+
+typedef enum VSMediaType {
+    mtVideo = 1,
+    mtAudio = 2
+} VSMediaType;
+
+typedef struct VSVideoFormat {
+    int colorFamily; /* see VSColorFamily */
+    int sampleType; /* see VSSampleType */
+    int bitsPerSample; /* number of significant bits */
+    int bytesPerSample; /* actual storage is always in a power of 2 and the smallest possible that can fit the number of bits used per sample */
+
+    int subSamplingW; /* log2 subsampling factor, applied to second and third plane */
+    int subSamplingH; /* log2 subsampling factor, applied to second and third plane */
+
+    int numPlanes; /* implicit from colorFamily */
+} VSVideoFormat;
+
+typedef enum VSAudioChannels {
+    acFrontLeft           = 0,
+    acFrontRight          = 1,
+    acFrontCenter         = 2,
+    acLowFrequency        = 3,
+    acBackLeft            = 4,
+    acBackRight           = 5,
+    acFrontLeftOFCenter   = 6,
+    acFrontRightOFCenter  = 7,
+    acBackCenter          = 8,
+    acSideLeft            = 9,
+    acSideRight           = 10,
+    acTopCenter           = 11,
+    acTopFrontLeft        = 12,
+    acTopFrontCenter      = 13,
+    acTopFrontRight       = 14,
+    acTopBackLeft         = 15,
+    acTopBackCenter       = 16,
+    acTopBackRight        = 17,
+    acStereoLeft          = 29,
+    acStereoRight         = 30,
+    acWideLeft            = 31,
+    acWideRight           = 32,
+    acSurroundDirectLeft  = 33,
+    acSurroundDirectRight = 34,
+    acLowFrequency2       = 35
+} VSAudioChannels;
+
+typedef struct VSAudioFormat {
+    int sampleType;
+    int bitsPerSample;
+    int bytesPerSample; /* implicit from bitsPerSample */
+    int numChannels; /* implicit from channelLayout */
+    uint64_t channelLayout;
+} VSAudioFormat;
+
+typedef enum VSFilterFlags {
+    ffStrictSpatial = 1
+} VSFilterFlags;
+
+typedef enum VSPropertyType {
+    ptUnset = 0,
+    ptInt = 1,
+    ptFloat = 2,
+    ptData = 3,
+    ptFunction = 4,
+    ptVideoNode = 5,
+    ptAudioNode = 6,
+    ptVideoFrame = 7,
+    ptAudioFrame = 8
+} VSPropertyType;
+
+typedef enum VSMapPropertyError {
+    peSuccess = 0,
+    peUnset   = 1, /* no key exists */
+    peType    = 2, /* key exists but not of a compatible type */
+    peIndex   = 4, /* index out of bounds */
+    peError   = 3  /* map has error state set */
+} VSMapPropertyError;
+
+typedef enum VSMapAppendMode {
+    maReplace = 0,
+    maAppend  = 1
+} VSMapAppendMode;
+
+typedef struct VSCoreInfo {
+    const char *versionString;
+    int core;
+    int api;
+    int numThreads;
+    int64_t maxFramebufferSize;
+    int64_t usedFramebufferSize;
+} VSCoreInfo;
+
+typedef struct VSVideoInfo {
+    VSVideoFormat format;
+    int64_t fpsNum;
+    int64_t fpsDen;
+    int width;
+    int height;
+    int numFrames;
+} VSVideoInfo;
+
+typedef struct VSAudioInfo {
+    VSAudioFormat format;
+    int sampleRate;
+    int64_t numSamples;
+    int numFrames; /* the total number of audio frames needed to hold numSamples, implicit from numSamples when calling createAudioFilter */
+} VSAudioInfo;
+
+typedef enum VSActivationReason {
+    arInitial = 0,
+    arAllFramesReady = 1,
+    arError = -1
+} VSActivationReason;
+
+typedef enum VSMessageType {
+    mtDebug = 0,
+    mtInformation = 1, 
+    mtWarning = 2,
+    mtCritical = 3,
+    mtFatal = 4 /* also terminates the process, should generally not be used by normal filters */
+} VSMessageType;
+
+typedef enum VSCoreCreationFlags {
+    ccfEnableGraphInspection = 1,
+    ccfDisableAutoLoading = 2,
+    ccfDisableLibraryUnloading = 4
+} VSCoreCreationFlags;
+
+typedef enum VSPluginConfigFlags {
+    pcModifiable = 1
+} VSPluginConfigFlags;
+
+typedef enum VSDataTypeHint {
+    dtUnknown = -1,
+    dtBinary = 0,
+    dtUtf8 = 1
+} VSDataTypeHint;
+
+typedef enum VSRequestPattern {
+    rpGeneral = 0, /* General pattern */
+    rpNoFrameReuse = 1, /* When requesting all output frames from the filter no frame will be requested more than once from this input clip, never requests frames beyond the end of the clip */
+    rpStrictSpatial = 2 /* Always (and only) requests frame n from input clip when generating output frame n, never requests frames beyond the end of the clip */
+} VSRequestPattern;
+
+/* Core entry point */
+typedef const VSAPI *(VS_CC *VSGetVapourSynthAPI)(int version);
+
+/* Plugin, function and filter related */
+typedef void (VS_CC *VSPublicFunction)(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi);
+typedef void (VS_CC *VSInitPlugin)(VSPlugin *plugin, const VSPLUGINAPI *vspapi);
+typedef void (VS_CC *VSFreeFunctionData)(void *userData);
+typedef const VSFrame *(VS_CC *VSFilterGetFrame)(int n, int activationReason, void *instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi);
+typedef void (VS_CC *VSFilterFree)(void *instanceData, VSCore *core, const VSAPI *vsapi);
+
+/* Other */
+typedef void (VS_CC *VSFrameDoneCallback)(void *userData, const VSFrame *f, int n, VSNode *node, const char *errorMsg);
+typedef void (VS_CC *VSLogHandler)(int msgType, const char *msg, void *userData);
+typedef void (VS_CC *VSLogHandlerFree)(void *userData);
+
+struct VSPLUGINAPI {
+    int (VS_CC *getAPIVersion)(void) VS_NOEXCEPT; /* returns VAPOURSYNTH_API_VERSION of the library */
+    int (VS_CC *configPlugin)(const char *identifier, const char *pluginNamespace, const char *name, int pluginVersion, int apiVersion, int flags, VSPlugin *plugin) VS_NOEXCEPT; /* use the VS_MAKE_VERSION macro for pluginVersion */
+    int (VS_CC *registerFunction)(const char *name, const char *args, const char *returnType, VSPublicFunction argsFunc, void *functionData, VSPlugin *plugin) VS_NOEXCEPT; /* non-zero return value on success  */
+};
+
+typedef struct VSFilterDependency {
+    VSNode *source;
+    int requestPattern; /* VSRequestPattern */
+} VSFilterDependency;
+
+struct VSAPI {
+    /* Audio and video filter related including nodes */
+    void (VS_CC *createVideoFilter)(VSMap *out, const char *name, const VSVideoInfo *vi, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, const VSFilterDependency *dependencies, int numDeps, void *instanceData, VSCore *core) VS_NOEXCEPT; /* output nodes are appended to the clip key in the out map */
+    VSNode *(VS_CC *createVideoFilter2)(const char *name, const VSVideoInfo *vi, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, const VSFilterDependency *dependencies, int numDeps, void *instanceData, VSCore *core) VS_NOEXCEPT; /* same as createVideoFilter but returns a pointer to the VSNode directly or NULL on failure */
+    void (VS_CC *createAudioFilter)(VSMap *out, const char *name, const VSAudioInfo *ai, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, const VSFilterDependency *dependencies, int numDeps, void *instanceData, VSCore *core) VS_NOEXCEPT; /* output nodes are appended to the clip key in the out map */
+    VSNode *(VS_CC *createAudioFilter2)(const char *name, const VSAudioInfo *ai, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, const VSFilterDependency *dependencies, int numDeps, void *instanceData, VSCore *core) VS_NOEXCEPT; /* same as createAudioFilter but returns a pointer to the VSNode directly or NULL on failure */
+    int (VS_CC *setLinearFilter)(VSNode *node) VS_NOEXCEPT; /* Use right after create*Filter*, sets the correct cache mode for using the cacheFrame API and returns the recommended upper number of additional frames to cache per request */
+    void (VS_CC *setCacheMode)(VSNode *node, int mode) VS_NOEXCEPT; /* -1: default (auto), 0: force disable, 1: force enable, changing the cache mode also resets all options to their default */
+    void (VS_CC *setCacheOptions)(VSNode *node, int fixedSize, int maxSize, int maxHistorySize) VS_NOEXCEPT; /* passing -1 means no change */
+
+    void (VS_CC *freeNode)(VSNode *node) VS_NOEXCEPT;
+    VSNode *(VS_CC *addNodeRef)(VSNode *node) VS_NOEXCEPT;
+    int (VS_CC *getNodeType)(VSNode *node) VS_NOEXCEPT; /* returns VSMediaType */
+    const VSVideoInfo *(VS_CC *getVideoInfo)(VSNode *node) VS_NOEXCEPT;
+    const VSAudioInfo *(VS_CC *getAudioInfo)(VSNode *node) VS_NOEXCEPT;
+
+    /* Frame related functions */
+    VSFrame *(VS_CC *newVideoFrame)(const VSVideoFormat *format, int width, int height, const VSFrame *propSrc, VSCore *core) VS_NOEXCEPT;
+    VSFrame *(VS_CC *newVideoFrame2)(const VSVideoFormat *format, int width, int height, const VSFrame **planeSrc, const int *planes, const VSFrame *propSrc, VSCore *core) VS_NOEXCEPT; /* same as newVideoFrame but allows the specified planes to be effectively copied from the source frames */
+    VSFrame *(VS_CC *newAudioFrame)(const VSAudioFormat *format, int numSamples, const VSFrame *propSrc, VSCore *core) VS_NOEXCEPT;
+    VSFrame *(VS_CC *newAudioFrame2)(const VSAudioFormat *format, int numSamples, const VSFrame **channelSrc, const int *channels, const VSFrame *propSrc, VSCore *core) VS_NOEXCEPT; /* same as newAudioFrame but allows the specified channels to be effectively copied from the source frames */
+    void (VS_CC *freeFrame)(const VSFrame *f) VS_NOEXCEPT;
+    const VSFrame *(VS_CC *addFrameRef)(const VSFrame *f) VS_NOEXCEPT;
+    VSFrame *(VS_CC *copyFrame)(const VSFrame *f, VSCore *core) VS_NOEXCEPT;
+    const VSMap *(VS_CC *getFramePropertiesRO)(const VSFrame *f) VS_NOEXCEPT;
+    VSMap *(VS_CC *getFramePropertiesRW)(VSFrame *f) VS_NOEXCEPT;
+
+    ptrdiff_t (VS_CC *getStride)(const VSFrame *f, int plane) VS_NOEXCEPT;
+    const uint8_t *(VS_CC *getReadPtr)(const VSFrame *f, int plane) VS_NOEXCEPT;
+    uint8_t *(VS_CC *getWritePtr)(VSFrame *f, int plane) VS_NOEXCEPT; /* calling this function invalidates previously gotten read pointers to the same frame */
+
+    const VSVideoFormat *(VS_CC *getVideoFrameFormat)(const VSFrame *f) VS_NOEXCEPT;
+    const VSAudioFormat *(VS_CC *getAudioFrameFormat)(const VSFrame *f) VS_NOEXCEPT;
+    int (VS_CC *getFrameType)(const VSFrame *f) VS_NOEXCEPT; /* returns VSMediaType */
+    int (VS_CC *getFrameWidth)(const VSFrame *f, int plane) VS_NOEXCEPT;
+    int (VS_CC *getFrameHeight)(const VSFrame *f, int plane) VS_NOEXCEPT;
+    int (VS_CC *getFrameLength)(const VSFrame *f) VS_NOEXCEPT; /* returns the number of samples for audio frames */
+
+    /* General format functions  */
+    int (VS_CC *getVideoFormatName)(const VSVideoFormat *format, char *buffer) VS_NOEXCEPT; /* up to 32 characters including terminating null may be written to the buffer, non-zero return value on success */
+    int (VS_CC *getAudioFormatName)(const VSAudioFormat *format, char *buffer) VS_NOEXCEPT; /* up to 32 characters including terminating null may be written to the buffer, non-zero return value on success */
+    int (VS_CC *queryVideoFormat)(VSVideoFormat *format, int colorFamily, int sampleType, int bitsPerSample, int subSamplingW, int subSamplingH, VSCore *core) VS_NOEXCEPT; /* non-zero return value on success */
+    int (VS_CC *queryAudioFormat)(VSAudioFormat *format, int sampleType, int bitsPerSample, uint64_t channelLayout, VSCore *core) VS_NOEXCEPT; /* non-zero return value on success */
+    uint32_t (VS_CC *queryVideoFormatID)(int colorFamily, int sampleType, int bitsPerSample, int subSamplingW, int subSamplingH, VSCore *core) VS_NOEXCEPT; /* returns 0 on failure */
+    int (VS_CC *getVideoFormatByID)(VSVideoFormat *format, uint32_t id, VSCore *core) VS_NOEXCEPT; /* non-zero return value on success */
+
+    /* Frame request and filter getframe functions */
+    const VSFrame *(VS_CC *getFrame)(int n, VSNode *node, char *errorMsg, int bufSize) VS_NOEXCEPT; /* only for external applications using the core as a library or for requesting frames in a filter constructor, do not use inside a filter's getframe function */
+    void (VS_CC *getFrameAsync)(int n, VSNode *node, VSFrameDoneCallback callback, void *userData) VS_NOEXCEPT; /* only for external applications using the core as a library or for requesting frames in a filter constructor, do not use inside a filter's getframe function */
+    const VSFrame *(VS_CC *getFrameFilter)(int n, VSNode *node, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
+    void (VS_CC *requestFrameFilter)(int n, VSNode *node, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
+    void (VS_CC *releaseFrameEarly)(VSNode *node, int n, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function, unless this function is called a requested frame is kept in memory until the end of processing the current frame */
+    void (VS_CC *cacheFrame)(const VSFrame *frame, int n, VSFrameContext *frameCtx) VS_NOEXCEPT; /* used to store intermediate frames in cache, useful for filters where random access is slow, must call setLinearFilter on the node before using or the result is undefined  */
+    void (VS_CC *setFilterError)(const char *errorMessage, VSFrameContext *frameCtx) VS_NOEXCEPT; /* used to signal errors in the filter getframe function */
+
+    /* External functions */
+    VSFunction *(VS_CC *createFunction)(VSPublicFunction func, void *userData, VSFreeFunctionData free, VSCore *core) VS_NOEXCEPT;
+    void (VS_CC *freeFunction)(VSFunction *f) VS_NOEXCEPT;
+    VSFunction *(VS_CC *addFunctionRef)(VSFunction *f) VS_NOEXCEPT;
+    void (VS_CC *callFunction)(VSFunction *func, const VSMap *in, VSMap *out) VS_NOEXCEPT;
+
+    /* Map and property access functions */
+    VSMap *(VS_CC *createMap)(void) VS_NOEXCEPT;
+    void (VS_CC *freeMap)(VSMap *map) VS_NOEXCEPT;
+    void (VS_CC *clearMap)(VSMap *map) VS_NOEXCEPT;
+    void (VS_CC *copyMap)(const VSMap *src, VSMap *dst) VS_NOEXCEPT; /* copies all values in src to dst, if a key already exists in dst it's replaced */
+
+    void (VS_CC *mapSetError)(VSMap *map, const char *errorMessage) VS_NOEXCEPT; /* used to signal errors outside filter getframe function */
+    const char *(VS_CC *mapGetError)(const VSMap *map) VS_NOEXCEPT; /* used to query errors, returns 0 if no error */
+
+    int (VS_CC *mapNumKeys)(const VSMap *map) VS_NOEXCEPT;
+    const char *(VS_CC *mapGetKey)(const VSMap *map, int index) VS_NOEXCEPT;
+    int (VS_CC *mapDeleteKey)(VSMap *map, const char *key) VS_NOEXCEPT;
+    int (VS_CC *mapNumElements)(const VSMap *map, const char *key) VS_NOEXCEPT; /* returns -1 if a key doesn't exist */
+    int (VS_CC *mapGetType)(const VSMap *map, const char *key) VS_NOEXCEPT; /* returns VSPropertyType */
+    int (VS_CC *mapSetEmpty)(VSMap *map, const char *key, int type) VS_NOEXCEPT;
+
+    int64_t (VS_CC *mapGetInt)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapGetIntSaturated)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    const int64_t *(VS_CC *mapGetIntArray)(const VSMap *map, const char *key, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapSetInt)(VSMap *map, const char *key, int64_t i, int append) VS_NOEXCEPT;
+    int (VS_CC *mapSetIntArray)(VSMap *map, const char *key, const int64_t *i, int size) VS_NOEXCEPT;
+
+    double (VS_CC *mapGetFloat)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    float (VS_CC *mapGetFloatSaturated)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    const double *(VS_CC *mapGetFloatArray)(const VSMap *map, const char *key, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapSetFloat)(VSMap *map, const char *key, double d, int append) VS_NOEXCEPT;
+    int (VS_CC *mapSetFloatArray)(VSMap *map, const char *key, const double *d, int size) VS_NOEXCEPT;
+
+    const char *(VS_CC *mapGetData)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapGetDataSize)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapGetDataTypeHint)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT; /* returns VSDataTypeHint */
+    int (VS_CC *mapSetData)(VSMap *map, const char *key, const char *data, int size, int type, int append) VS_NOEXCEPT;
+
+    VSNode *(VS_CC *mapGetNode)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapSetNode)(VSMap *map, const char *key, VSNode *node, int append) VS_NOEXCEPT; /* returns 0 on success */
+    int (VS_CC *mapConsumeNode)(VSMap *map, const char *key, VSNode *node, int append) VS_NOEXCEPT; /* always consumes the reference, even on error */
+
+    const VSFrame *(VS_CC *mapGetFrame)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapSetFrame)(VSMap *map, const char *key, const VSFrame *f, int append) VS_NOEXCEPT; /* returns 0 on success */
+    int (VS_CC *mapConsumeFrame)(VSMap *map, const char *key, const VSFrame *f, int append) VS_NOEXCEPT; /* always consumes the reference, even on error */
+
+    VSFunction *(VS_CC *mapGetFunction)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *mapSetFunction)(VSMap *map, const char *key, VSFunction *func, int append) VS_NOEXCEPT; /* returns 0 on success */
+    int (VS_CC *mapConsumeFunction)(VSMap *map, const char *key, VSFunction *func, int append) VS_NOEXCEPT; /* always consumes the reference, even on error */
+
+    /* Plugin and plugin function related */
+    int (VS_CC *registerFunction)(const char *name, const char *args, const char *returnType, VSPublicFunction argsFunc, void *functionData, VSPlugin *plugin) VS_NOEXCEPT; /* non-zero return value on success  */
+    VSPlugin *(VS_CC *getPluginByID)(const char *identifier, VSCore *core) VS_NOEXCEPT;
+    VSPlugin *(VS_CC *getPluginByNamespace)(const char *ns, VSCore *core) VS_NOEXCEPT;
+    VSPlugin *(VS_CC *getNextPlugin)(VSPlugin *plugin, VSCore *core) VS_NOEXCEPT; /* pass NULL to get the first plugin  */
+    const char *(VS_CC *getPluginName)(VSPlugin *plugin) VS_NOEXCEPT;
+    const char *(VS_CC *getPluginID)(VSPlugin *plugin) VS_NOEXCEPT;
+    const char *(VS_CC *getPluginNamespace)(VSPlugin *plugin) VS_NOEXCEPT;
+    VSPluginFunction *(VS_CC *getNextPluginFunction)(VSPluginFunction *func, VSPlugin *plugin) VS_NOEXCEPT; /* pass NULL to get the first plugin function  */
+    VSPluginFunction *(VS_CC *getPluginFunctionByName)(const char *name, VSPlugin *plugin) VS_NOEXCEPT;
+    const char *(VS_CC *getPluginFunctionName)(VSPluginFunction *func) VS_NOEXCEPT;
+    const char *(VS_CC *getPluginFunctionArguments)(VSPluginFunction *func) VS_NOEXCEPT; /* returns an argument format string */
+    const char *(VS_CC *getPluginFunctionReturnType)(VSPluginFunction *func) VS_NOEXCEPT; /* returns an argument format string */
+    const char *(VS_CC *getPluginPath)(const VSPlugin *plugin) VS_NOEXCEPT; /* the full path to the loaded library file containing the plugin entry point */
+    int (VS_CC *getPluginVersion)(const VSPlugin *plugin) VS_NOEXCEPT;
+    VSMap *(VS_CC *invoke)(VSPlugin *plugin, const char *name, const VSMap *args) VS_NOEXCEPT; /* user must free the returned VSMap */
+
+    /* Core and information */
+    VSCore *(VS_CC *createCore)(int flags) VS_NOEXCEPT; /* flags uses the VSCoreCreationFlags enum */
+    void (VS_CC *freeCore)(VSCore *core) VS_NOEXCEPT; /* only call this function after all node, frame and function references belonging to the core have been freed */
+    int64_t(VS_CC *setMaxCacheSize)(int64_t bytes, VSCore *core) VS_NOEXCEPT; /* the total cache size at which vapoursynth more aggressively tries to reclaim memory, it is not a hard limit */
+    int (VS_CC *setThreadCount)(int threads, VSCore *core) VS_NOEXCEPT; /* setting threads to 0 means automatic detection */
+    void (VS_CC *getCoreInfo)(VSCore *core, VSCoreInfo *info) VS_NOEXCEPT;
+    int (VS_CC *getAPIVersion)(void) VS_NOEXCEPT;
+
+    /* Message handler */
+    void (VS_CC *logMessage)(int msgType, const char *msg, VSCore *core) VS_NOEXCEPT;
+    VSLogHandle *(VS_CC *addLogHandler)(VSLogHandler handler, VSLogHandlerFree free, void *userData, VSCore *core) VS_NOEXCEPT; /* free and userData can be NULL, returns a handle that can be passed to removeLogHandler */
+    int (VS_CC *removeLogHandler)(VSLogHandle *handle, VSCore *core) VS_NOEXCEPT; /* returns non-zero if successfully removed */
+    
+#ifdef VS_GRAPH_API
+    /* Graph information */
+
+    /* 
+     * NOT PART OF THE STABLE API!
+     * These functions only exist to retrieve internal details for debug purposes and graph visualization
+     * They will only only work properly when used on a core created with ccfEnableGraphInspection and are
+     * not safe to use concurrently with frame requests or other API functions
+     * NOT PART OF THE STABLE API!
+     */
+    
+    const char *(VS_CC *getNodeCreationFunctionName)(VSNode *node, int level) VS_NOEXCEPT; /* level=0 returns the name of the function that created the filter, specifying a higher level will retrieve the function above that invoked it or NULL if a non-existent level is requested */
+    const VSMap *(VS_CC *getNodeCreationFunctionArguments)(VSNode *node, int level) VS_NOEXCEPT; /* level=0 returns a copy of the arguments passed to the function that created the filter, returns NULL if a non-existent level is requested */
+    const char *(VS_CC *getNodeName)(VSNode *node) VS_NOEXCEPT; /* the name passed to create*Filter */
+    int (VS_CC *getNodeFilterMode)(VSNode *node) VS_NOEXCEPT; /* VSFilterMode */
+    int64_t (VS_CC *getNodeFilterTime)(VSNode *node) VS_NOEXCEPT; /* time spent processing frames in nanoseconds */
+    const VSFilterDependency *(VS_CC *getNodeDependencies)(VSNode *node) VS_NOEXCEPT;
+    int (VS_CC *getNumNodeDependencies)(VSNode *node) VS_NOEXCEPT;
+#endif
+};
+
+VS_API(const VSAPI *) getVapourSynthAPI(int version) VS_NOEXCEPT;
+
+#endif /* VAPOURSYNTH4_H */

--- a/src/neo_f3kdb.hpp
+++ b/src/neo_f3kdb.hpp
@@ -14,6 +14,7 @@ namespace Plugin {
   const char* Identifier = "in.7086.neo_f3kdb";
   const char* Namespace = "neo_f3kdb";
   const char* Description = "Neo F3KDB Deband Filter " PLUGIN_VERSION;
+  const int Version = 8;
 }
 
 std::vector<register_vsfilter_proc> RegisterVSFilters()


### PR DESCRIPTION
VapourSynth got a big API change in R55 which broke compatibility with many plugins.

Note that I almost didn't change any code in the plugin, apart from adding `Plugin::Version`. I still need to figure out how to get a number out of the release tag, but it shouldn't be too complicated.

Tested only under windows.