### PR TITLE
Add sample mode 5 (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ core.neo_f3kdb.Deband(clip, y=64, cb=64, cr=64, grainy=0, grainc=0, ...)
 
             (A + B) / 2
 
+    * 5: Similar to sample mode 4 but performing additional checks for better details preserving. (> r8)\
+        For more info - https://forum.doom9.org/showthread.php?p=1652256#post1652256 (avgDif, maxDif, midDif1, midDif2)\
+        `blur_first` doesn't have effect for this sample mode.
+
     Reference points are randomly picked within the `range`.
 
 - *input_depth* (removed)
@@ -60,11 +64,15 @@ core.neo_f3kdb.Deband(clip, y=64, cb=64, cr=64, grainy=0, grainc=0, ...)
 
     If you notice a dead lock under extreme condition, try disabling it.
 
-- *Y2*, *Cb2*, *Cr2* (> r7)
+- *scale* (> r8)
 
-    When specified respectively `Y`, `Cb`, `Cr` do not have effect.
+    Whether to use threshold parameters (Y, Cb, Cr...) within the internal bit depth range (0..65535).
+    
+    Default: false.
+    
+- *Y_1 / Cb_1 / Cr_1 (maxDif),  Y_2 / Cb_2 / Cr_2 (midDif1, midDif2)* (> r8)
 
-    `Y`, `Cb`, `Cr` are internally left shifted by `2` while `Y2`, `Cb2`, `Cr2` - by `5`.
+    Additional thresholds for `sample_mode=5`.    
 
 ## Compilation
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -132,6 +132,7 @@ void f3kdb_core_t::init_frame_luts(void)
                 break;
             
             case 2:
+            case 5:
             case 4:
                 cur_range = min_multi(x_range, y_range, -1);
                 break;
@@ -293,6 +294,8 @@ void f3kdb_core_t::process_plane(int frame_index, int plane, unsigned char* dst_
     case 0:
         params.info_ptr_base = _y_info;
         params.threshold = _params.Y;
+        params.threshold1 = _params.Y_1;
+        params.threshold2 = _params.Y_2;
         params.pixel_max = _params.keep_tv_range ? TV_RANGE_Y_MAX : FULL_RANGE_Y_MAX;
         params.pixel_min = _params.keep_tv_range ? TV_RANGE_Y_MIN : FULL_RANGE_Y_MIN;
         params.grain_buffer = _grain_buffer_y;
@@ -302,6 +305,8 @@ void f3kdb_core_t::process_plane(int frame_index, int plane, unsigned char* dst_
     case 1:
         params.info_ptr_base = _cb_info;
         params.threshold = _params.Cb;
+        params.threshold1 = _params.Cb_1;
+        params.threshold2 = _params.Cb_2;
         params.pixel_max = _params.keep_tv_range ? TV_RANGE_C_MAX : FULL_RANGE_C_MAX;
         params.pixel_min = _params.keep_tv_range ? TV_RANGE_C_MIN : FULL_RANGE_C_MIN;
         params.grain_buffer = _grain_buffer_c;
@@ -311,6 +316,8 @@ void f3kdb_core_t::process_plane(int frame_index, int plane, unsigned char* dst_
     case 2:
         params.info_ptr_base = _cr_info;
         params.threshold = _params.Cr;
+        params.threshold1 = _params.Cr_1;
+        params.threshold2 = _params.Cr_2;
         params.pixel_max = _params.keep_tv_range ? TV_RANGE_C_MAX : FULL_RANGE_C_MAX;
         params.pixel_min = _params.keep_tv_range ? TV_RANGE_C_MIN : FULL_RANGE_C_MIN;
         params.grain_buffer = _grain_buffer_c;

--- a/src/core.h
+++ b/src/core.h
@@ -31,6 +31,8 @@ typedef struct _process_plane_params
     int output_depth;
 
     unsigned short threshold;
+    unsigned short threshold1;
+    unsigned short threshold2;
     pixel_dither_info *info_ptr_base;
     int info_stride;
     

--- a/src/f3kdb.h
+++ b/src/f3kdb.h
@@ -54,4 +54,10 @@ typedef struct _f3kdb_params_t {
   RANDOM_ALGORITHM random_algo_grain {RANDOM_ALGORITHM_UNIFORM};
   double random_param_ref {1.0f};
   double random_param_grain {1.0f};
+  int Y_1 {-1};
+  int Cb_1 {-1};
+  int Cr_1 {-1};
+  int Y_2 {-1};
+  int Cb_2 {-1};
+  int Cr_2 {-1};
 } f3kdb_params_t;

--- a/src/impl_dispatch_decl.h
+++ b/src/impl_dispatch_decl.h
@@ -13,7 +13,8 @@
 					impl_func_mode3_blur, \
 					impl_func_mode3_noblur, \
 					impl_func_mode4_blur, \
-					impl_func_mode4_noblur) \
+					impl_func_mode4_noblur, \
+					impl_func_mode5_noblur) \
 	extern const process_plane_impl_t process_plane_impl_##n [];
 
 #else
@@ -27,7 +28,8 @@
 					impl_func_mode3_blur, \
 					impl_func_mode3_noblur, \
 					impl_func_mode4_blur, \
-					impl_func_mode4_noblur) \
+					impl_func_mode4_noblur, \
+					impl_func_mode5_noblur) \
 	extern const process_plane_impl_t process_plane_impl_##n [] = { \
 					nullptr, \
 					impl_func_mode1_blur, \
@@ -37,7 +39,8 @@
 					impl_func_mode3_blur, \
 					impl_func_mode3_noblur, \
 					impl_func_mode4_blur, \
-					impl_func_mode4_noblur};
+					impl_func_mode4_noblur, \
+					impl_func_mode5_noblur};
 
 #endif
 
@@ -52,7 +55,8 @@
 				(&impl_func<3, true, __VA_ARGS__>), \
 				(&impl_func<3, false, __VA_ARGS__>), \
 				(&impl_func<4, true, __VA_ARGS__>), \
-				(&impl_func<4, false, __VA_ARGS__>) );
+				(&impl_func<4, false, __VA_ARGS__>), \
+				(&impl_func<5, false, __VA_ARGS__>) );
 
 #define DEFINE_SSE_IMPL(name, ...) \
 	DEFINE_TEMPLATE_IMPL(name, process_plane_sse_impl, __VA_ARGS__);


### PR DESCRIPTION
Add sample mode 5 - similar to sample mode 4 but with additional threshold checks - https://forum.doom9.org/showthread.php?p=1652256#post1652256 (#13) (avgDif, maxDif, midDif1, midDif2).

Also add new parameters for these additional checks (`Y_1`, `Cb_1`, `Cr_1`,` Y_2`, `Cb_2`, `Cr_2`).

Remove parameters `y2`, `cb2`, `cr2` and add parameter `scale`. This way it's easily to change the behavior of the threshold parameters without adding second parameter for every threshold.