### PR TITLE
Fix undefined symbols on non-x86 platforms

### DIFF
--- a/src/flash3kyuu_deband_sse_base.h
+++ b/src/flash3kyuu_deband_sse_base.h
@@ -4,7 +4,13 @@
 #include "impl_dispatch.h"
 #include "sse_utils.h"
 #include "dither_high.h"
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
 #include "VCL2/vectorclass.h"
+#else
+#define __asm(...) __builtin_trap()
+#include "VCL2/vectorclass.h"
+#undef __asm
+#endif
 #include "VCL2/vectormath_exp.h"
 
 /****************************************************************************


### PR DESCRIPTION
Fix error from issue #27 :

```
[alarm@localhost WebRip999]$ vspipe -c y4m tmp.vpy tets.y4m                                              
Warning: Failed to load /usr/lib/vapoursynth/libneo-f3kdb.so. Error given: /usr/lib/vapoursynth/libneo-f3kdb.so: undefined symbol: process_plane_impl_sse4_16bit_interleaved
```

No need for additional range checks, because at f3kdb.hpp:152 the code won't allow the array index to go beyond "C" optimization without detecting them on CPU.
UPD: but CPU capabilities return SSE support on ARM (it is hardcoded)... So that I had to fix it in another commit.