### PR TITLE
Make the scalar and SIMD output identical (except sample_mode=2)

### DIFF
--- a/src/pixel_proc_c_high_bit_depth_common.h
+++ b/src/pixel_proc_c_high_bit_depth_common.h
@@ -15,7 +15,7 @@
         return clamp_pixel(pixel, pixel_min, pixel_max) >> (INTERNAL_BIT_DEPTH - output_depth);
     }
 #endif
-    
+
     static inline int avg_2(void* context, int pixel1, int pixel2)
     {
         return (pixel1 + pixel2 + 1) >> 1;
@@ -23,13 +23,6 @@
 
     static inline int avg_4(void* context, int pixel1, int pixel2, int pixel3, int pixel4)
     {
-        // consistent with SSE code
-        int avg1 = (pixel1 + pixel2 + 1) >> 1;
-        int avg2 = (pixel3 + pixel4 + 1) >> 1;
-        if (avg1 > 0)
-        {
-            avg1 -= 1;
-        }
-        return (avg1 + avg2 + 1) >> 1;
+        return (pixel1 + pixel2 + pixel3 + pixel4) >> 2;
     }
 


### PR DESCRIPTION
This makes `avg_4` identical to the SIMD math.